### PR TITLE
Added support for magicmethods on Event Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,4 @@ server-folder/gamemodes/*
 server-folder/crashinfo.txt
 server-folder/libmysql.dll
 server-folder/libphp5.so
+server-folder/php/kanti_/

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,11 @@ server-folder/announce*
 server-folder/samp-*
 server-folder/server*
 server-folder/scriptfiles/*
+server-folder/php/.idea/*
+server-folder/php/kanti/*
+server-folder/pawno/*
+server-folder/npcmodes/*
+server-folder/gamemodes/*
+server-folder/crashinfo.txt
+server-folder/libmysql.dll
+server-folder/libphp5.so

--- a/server-folder/php/core/callbacks.txt
+++ b/server-folder/php/core/callbacks.txt
@@ -41,7 +41,6 @@ OnPlayerText
 OnPlayerUpdate
 OnRconCommand
 OnRconLoginAttempt
-OnUnoccupiedVehicleUpdate
 OnVehicleDamageStatusUpdate
 OnVehicleDeath
 OnVehicleMod

--- a/server-folder/php/core/event.php
+++ b/server-folder/php/core/event.php
@@ -1,18 +1,84 @@
 <?php
+
+/**
+ * Class Event * @method static bool onDialogResponse(mixed $eventFunction)
+ * @method static bool onEnterExitModShop(mixed $eventFunction)
+ * @method static bool onGameModeExit(mixed $eventFunction)
+ * @method static bool onGameModeInit(mixed $eventFunction)
+ * @method static bool onObjectMoved(mixed $eventFunction)
+ * @method static bool onPlayerClickMap(mixed $eventFunction)
+ * @method static bool onPlayerClickPlayer(mixed $eventFunction)
+ * @method static bool onPlayerClickPlayerTextDraw(mixed $eventFunction)
+ * @method static bool onPlayerClickTextDraw(mixed $eventFunction)
+ * @method static bool onPlayerCommandText(mixed $eventFunction)
+ * @method static bool onPlayerConnect(mixed $eventFunction)
+ * @method static bool onPlayerDeath(mixed $eventFunction)
+ * @method static bool onPlayerDisconnect(mixed $eventFunction)
+ * @method static bool onPlayerEditAttachedObject(mixed $eventFunction)
+ * @method static bool onPlayerEditObject(mixed $eventFunction)
+ * @method static bool onPlayerEnterCheckpoint(mixed $eventFunction)
+ * @method static bool onPlayerEnterRaceCheckpoint(mixed $eventFunction)
+ * @method static bool onPlayerEnterVehicle(mixed $eventFunction)
+ * @method static bool onPlayerExitVehicle(mixed $eventFunction)
+ * @method static bool onPlayerExitedMenu(mixed $eventFunction)
+ * @method static bool onPlayerGiveDamage(mixed $eventFunction)
+ * @method static bool onPlayerInteriorChange(mixed $eventFunction)
+ * @method static bool onPlayerKeyStateChange(mixed $eventFunction)
+ * @method static bool onPlayerLeaveCheckpoint(mixed $eventFunction)
+ * @method static bool onPlayerLeaveRaceCheckpoint(mixed $eventFunction)
+ * @method static bool onPlayerObjectMoved(mixed $eventFunction)
+ * @method static bool onPlayerPickUpPickup(mixed $eventFunction)
+ * @method static bool onPlayerPrivmsg(mixed $eventFunction)
+ * @method static bool onPlayerRequestClass(mixed $eventFunction)
+ * @method static bool onPlayerRequestSpawn(mixed $eventFunction)
+ * @method static bool onPlayerSelectObject(mixed $eventFunction)
+ * @method static bool onPlayerSelectedMenuRow(mixed $eventFunction)
+ * @method static bool onPlayerSpawn(mixed $eventFunction)
+ * @method static bool onPlayerStateChange(mixed $eventFunction)
+ * @method static bool onPlayerStreamIn(mixed $eventFunction)
+ * @method static bool onPlayerStreamOut(mixed $eventFunction)
+ * @method static bool onPlayerTakeDamage(mixed $eventFunction)
+ * @method static bool onPlayerWeaponShot(mixed $eventFunction)
+ * @method static bool onPlayerTeamPrivmsg(mixed $eventFunction)
+ * @method static bool onPlayerText(mixed $eventFunction)
+ * @method static bool onPlayerUpdate(mixed $eventFunction)
+ * @method static bool onRconCommand(mixed $eventFunction)
+ * @method static bool onRconLoginAttempt(mixed $eventFunction)
+ * @method static bool onVehicleDamageStatusUpdate(mixed $eventFunction)
+ * @method static bool onVehicleDeath(mixed $eventFunction)
+ * @method static bool onVehicleMod(mixed $eventFunction)
+ * @method static bool onVehiclePaintjob(mixed $eventFunction)
+ * @method static bool onVehicleRespray(mixed $eventFunction)
+ * @method static bool onVehicleSpawn(mixed $eventFunction)
+ * @method static bool onVehicleStreamIn(mixed $eventFunction)
+ * @method static bool onVehicleStreamOut(mixed $eventFunction)
+ * @method static bool onIncomingConnection(mixed $eventFunction)
+ * @method static bool onTrailerUpdate(mixed $eventFunction)
+ * @method static bool onUnoccupiedVehicleUpdate(mixed $eventFunction)
+ */
 class Event
 {
 	protected static $events = array(
 		'on' => array(),
 		'after' => array(),
 	);
-	
-	
+
+    public static function __callStatic($name, $arguments)
+    {
+        if (substr($name, 0, 2) == "on" && count($arguments) == 1) {
+            $eventId = substr($name, 2);
+            static::on($eventId, $arguments[0]);
+            return true;
+        }
+    }
+
+
 	public static function on($eventId, $eventFunction)
 	{
 		if(is_callable($eventFunction))
 			static::$events['on'][$eventId][] = $eventFunction;
 	}
-	
+
 	public static function after($eventId, $eventFunction)
 	{
 		if(is_callable($eventFunction))

--- a/server-folder/php/core/player.php
+++ b/server-folder/php/core/player.php
@@ -10,6 +10,7 @@ class Player
 
 	public $id;
 
+    /** @var PlayerCamera  */
 	public $camera = null;
 
 	public static function find($id)

--- a/server-folder/php/core/playertext3d.php
+++ b/server-folder/php/core/playertext3d.php
@@ -18,9 +18,9 @@ class PlayerText3D
 	}
 
 	public static function create($player, $text, $color, $x, $y, $z, $drawDistance = 100.0,
-		$attachedplayer = INVALID_PLAYER_ID, $attachedvehicle = INVALID_VEHICLE_ID, $virtualworld = 0, $testLOS = false)
+		$attachedplayer = INVALID_PLAYER_ID, $attachedvehicle = INVALID_VEHICLE_ID, $testLOS = false)
 	{
-		$id = CreatePlayer3DTextLabel($player->id, $text, $color, $x, $y, $z, $drawDistance, $attachedplayer, $attachedvehicle, $virtualworld, $testLOS);
+		$id = CreatePlayer3DTextLabel($player->id, $text, $color, $x, $y, $z, $drawDistance, $attachedplayer, $attachedvehicle, $testLOS);
         if(!isset(static::$instances[$player->id])){
             static::$instances[$player->id] = array();
         }


### PR DESCRIPTION
hi there,

I have added static call of the Events:

Old version of a call:
```php
Event::on("PlayerSpawn", function(Player $player){
});
```
New Version of a call:
```php
Event::onPlayerSpawn(function(Player $player){
});
```
the old way is still posible.

Thanks phpdoc, autocomplete can see the methods and it is easier to code SAMPHP. :)